### PR TITLE
Fixed bug in cases where duplicate file names existed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - Updated structure fill code to be cleaner
 
 #### 5.2
+- Filename Duplicates (e.g. *_1.dat) are not recognized by UTESpac. This happens when the logger is reset within a minute as filenames have timestamp only down to the minute.
 - Added 2 examples, data from MATERHORN Playa and Oregon Vineyard.
 - Will work with old 2 day files and new hourly files
 - Added ability to change folder structure. i.e. siteinfo.m, headers, and data files do not necessarily have to be in .../siteXYZ/

--- a/UTESpac.m
+++ b/UTESpac.m
@@ -59,7 +59,7 @@ close all; clearvars; clc;
 info.UTESpacVersion = '5.2';
 
 % enter root folder where site* folders are located
-%info.rootFolder = 'H:\Alexei\Data\C-FOG\Data\Ferryland - Battery';
+%info.rootFolder = '/uufs/chpc.utah.edu/common/home/IPAQS-group1/IPAQS19/Travis_Scratch/Data/Sonic_Array';
 info.rootFolder = '/uufs/chpc.utah.edu/common/home/IPAQS-group1/IPAQS19/Data/Sonic_Array';
 
 % folder structure between site folder and CSV files
@@ -67,6 +67,7 @@ info.rootFolder = '/uufs/chpc.utah.edu/common/home/IPAQS-group1/IPAQS19/Data/Son
 %   .../siteXYZ/*.dat       -> info.foldstruct = '';
 %   .../siteXYZ/CSV/*.dat   -> info.foldstruct = [filesep, 'CSV'];
 info.foldStruct = [filesep, 'CSV'];
+%info.foldStruct = '';
 
 % Enter regular expression for file for
 % fields of <Year>, <Month>, <Day> are required
@@ -164,12 +165,12 @@ info.diagnosticTest.meanLiGasDiagnosticLimit = 220;  % Full strength is 255, les
 template.u = 'Ux_*'; % sonic u  --   [m/s]
 template.v = 'Uy_*'; % sonic v  --   [m/s]
 template.w = 'Uz_*'; % sonic w  --   [m/s]
-template.Tson = 'T_Sonic_*'; % sonic T  --   [C or K]
-template.sonDiagnostic = 'sonic_diag_*'; % sonic diagnostic  --  [-]
+template.Tson = 'Ts_*'; % sonic T  --   [C or K]
+template.sonDiagnostic = 'diag_sonic_*'; % sonic diagnostic  --  [-]
 template.fw = 'fw_*'; % sonic finewires to be used for Eddy Covariance  --  [C]
 template.RH = 'RH_HMP_*'; % slow response relative humidity for virtual temperature calculation  --  [Fract or %]
 template.T = 'T_HMP_*'; % slow response temperature  --  [C]
-template.P = 'Pressure_*'; % pressure  --  [kPa or mBar]
+template.P = 'pressure'; % pressure  --  [kPa or mBar]
 template.irgaH2O = 'H2O_*'; % for use with Campbell EC150 and IRGASON.  WPL corrections applied  --  [g/m^3]
 template.irgaH2OsigStrength = 'H2OSig_*'; % EC150 Signal Strength  --  [-]
 template.irgaCO2 = 'CO2_*'; % for use with Campbell EC150 and IRGASON.  WPL corrections applied  --  [mg/m^3]


### PR DESCRIPTION
e.g. folder contains
CSV_6989.PWID_FastResponse_2019_06_17_1924.dat
CSV_6989.PWID_FastResponse_2019_06_17_1924_1.dat

UTESpac will now recognize the second file